### PR TITLE
Add merged emoji and disable notification when draft

### DIFF
--- a/app/services/slack_notification_service.rb
+++ b/app/services/slack_notification_service.rb
@@ -1,8 +1,10 @@
 class SlackNotificationService
   ACTION_METHODS = {
     'opened' => :filter_opened_action,
+    'ready_for_review' => :filter_ready_for_review_action,
     'unlabeled' => :filter_unlabeled_action,
-    'labeled' => :filter_on_hold_labeled_action
+    'labeled' => :filter_on_hold_labeled_action,
+    'closed' => :filter_closed_action,
   }.freeze
   EMOJI_HASH =  {
     'JavaScript' => ':javascript:',
@@ -17,6 +19,7 @@ class SlackNotificationService
     'Python' => ':python:',
     'HTML' => ':html5:'
   }.freeze
+
   ON_HOLD = 'ON HOLD'.freeze
   CHANNEL = '#code-review'.freeze
 
@@ -42,21 +45,47 @@ class SlackNotificationService
 
   def filter_unlabeled_action
     label_name = extra_params[:github_webhook][:label][:name]
-    notify_pull_request if on_hold? label_name
+    notify_pull_request if on_hold_label? label_name
   end
 
   def filter_on_hold_labeled_action
     label_name = extra_params[:github_webhook][:label][:name]
     pull_request_url = extra_params[:pull_request][:html_url]
-    return unless on_hold?(label_name)
+    return unless on_hold_label?(label_name)
 
     matches = find_message pull_request_url
     delete_message matches
   end
 
   def filter_opened_action
-    labels = extra_params[:pull_request][:labels]
-    notify_pull_request unless labels&.any? { |label| on_hold? label[:name] }
+    is_draft = extra_params[:pull_request][:draft]
+    notify_pull_request unless on_hold_pr? || is_draft
+  end
+
+  def filter_ready_for_review_action
+    notify_pull_request unless on_hold_pr?
+  end
+
+  def filter_closed_action
+    is_merged = extra_params[:pull_request][:merged]
+    filter_merged_action if is_merged
+  end
+
+  def filter_merged_action
+    pull_request_url = extra_params[:pull_request][:html_url]
+    matches = find_message pull_request_url
+    add_merge_emoji matches
+  end
+
+  def add_merge_emoji(matches)
+    matches.each do |match|
+      timestamp = match[:ts]
+      begin
+        add_emoji :merged, timestamp
+      rescue Exception => ex
+        puts "An error of type #{ex.class} happened, message is #{ex.message}."
+      end
+    end
   end
 
   def find_message(text)
@@ -76,8 +105,13 @@ class SlackNotificationService
     end
   end
 
-  def on_hold?(label)
+  def on_hold_label?(label)
     label.downcase == ON_HOLD.downcase
+  end
+
+  def on_hold_pr?
+    labels = extra_params[:pull_request][:labels]
+    labels&.any? { |label| on_hold_label? label[:name] }
   end
 
   def message
@@ -110,4 +144,11 @@ class SlackNotificationService
     EMOJI_HASH.fetch language, "[#{language}]"
   end
 
+  def add_emoji(emoji, timestamp)
+    client.reactions_add(
+      name: emoji,
+      channel: CHANNEL,
+      timestamp: timestamp,
+      as_user: false)
+  end
 end


### PR DESCRIPTION
- When a PR is merged it will send the merged emoji to the message
- If a PR is a draft then it will not send the notification
- After then the draft changes to ready_for_review it will send the notification to slack