### PR TITLE
Add blacklist pr feature and refactor specs

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -1,12 +1,13 @@
 ActiveAdmin.register User do
-  permit_params :email, :first_name, :last_name, :username
+  permit_params :email, :first_name, :last_name, :github_name, :blacklisted
 
   form do |f|
     f.inputs 'Details' do
       f.input :email
       f.input :first_name
       f.input :last_name
-      f.input :username
+      f.input :github_name
+      f.input :blacklisted
     end
 
     actions
@@ -18,19 +19,19 @@ ActiveAdmin.register User do
     column :email
     column :first_name
     column :last_name
-    column :username
-    column :sign_in_count
+    column :github_name
+    column :blacklisted
     column :created_at
     column :updated_at
-
     actions
   end
 
   filter :id
   filter :email
-  filter :username
+  filter :github_name
   filter :first_name
   filter :last_name
+  filter :blacklisted
   filter :created_at
   filter :updated_at
 
@@ -40,8 +41,8 @@ ActiveAdmin.register User do
       row :email
       row :first_name
       row :last_name
-      row :username
-      row :sign_in_count
+      row :github_name
+      row :blacklisted
       row :created_at
       row :updated_at
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,37 +2,24 @@
 #
 # Table name: users
 #
-#  id                     :integer          not null, primary key
-#  email                  :string
-#  encrypted_password     :string           default(""), not null
-#  reset_password_token   :string
-#  reset_password_sent_at :datetime
-#  allow_password_change  :boolean          default(FALSE)
-#  remember_created_at    :datetime
-#  sign_in_count          :integer          default(0), not null
-#  current_sign_in_at     :datetime
-#  last_sign_in_at        :datetime
-#  current_sign_in_ip     :inet
-#  last_sign_in_ip        :inet
-#  first_name             :string           default("")
-#  last_name              :string           default("")
-#  username               :string           default("")
-#  created_at             :datetime         not null
-#  updated_at             :datetime         not null
-#  provider               :string           default("email"), not null
-#  uid                    :string           default(""), not null
-#  tokens                 :json
+#  id          :integer          not null, primary key
+#  email       :string
+#  first_name  :string           default("")
+#  last_name   :string           default("")
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  github_name :string
+#  slack_name  :string
+#  blacklisted :boolean          default(FALSE)
 #
 # Indexes
 #
-#  index_users_on_email                 (email) UNIQUE
-#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
-#  index_users_on_uid_and_provider      (uid,provider) UNIQUE
+#  index_users_on_github_name  (github_name)
 #
 
 class User < ApplicationRecord
   def full_name
-    return username unless first_name.present?
+    return github_name unless first_name.present?
     "#{first_name} #{last_name}"
   end
 end

--- a/app/services/pull_request.rb
+++ b/app/services/pull_request.rb
@@ -34,4 +34,8 @@ class PullRequest
     label.downcase == ON_HOLD.downcase
   end
 
+  def blacklisted?
+    User.where(github_name: username, blacklisted: true).exists?
+  end
+
 end

--- a/app/services/slack_bot.rb
+++ b/app/services/slack_bot.rb
@@ -24,7 +24,7 @@ class SlackBot
 
   def notify(message, username, avatar_url)
     client.chat_postMessage(channel: @channel, text: message, as_user: false, 
-                            username: username, icon_url: avatar_url )
+                            username: username, icon_url: avatar_url)
   end
 
   def add_merge_emoji(matches)

--- a/app/services/slack_notification_service.rb
+++ b/app/services/slack_notification_service.rb
@@ -19,6 +19,7 @@ class SlackNotificationService
   end
 
   def send_notification
+    return if @pr.blacklisted?
     send(ACTION_METHODS[action]) if ACTION_METHODS.key? action
   end
 

--- a/db/migrate/20190418132233_modify_users.rb
+++ b/db/migrate/20190418132233_modify_users.rb
@@ -1,0 +1,24 @@
+class ModifyUsers < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :users, :provider, :string, null: false, default: 'email'
+    remove_column :users, :uid, :string, null: false, default: ''
+    remove_column :users, :tokens, :json
+    remove_column :users, :encrypted_password, :string, null: false, default: ''
+    remove_column :users, :reset_password_token, :string
+    remove_column :users, :reset_password_sent_at, :datetime
+    remove_column :users, :allow_password_change, :boolean, default: false
+    remove_column :users, :remember_created_at, :datetime
+    remove_column :users, :sign_in_count, :integer, null: false, default: 0
+    remove_column :users, :current_sign_in_at, :datetime
+    remove_column :users, :last_sign_in_at, :datetime
+    remove_column :users, :current_sign_in_ip, :inet
+    remove_column :users, :last_sign_in_ip, :inet
+    remove_column :users, :username, :string, default: ''
+    remove_index :users, :email
+
+    add_column :users, :github_name, :string
+    add_index :users, :github_name
+    add_column :users, :slack_name, :string
+    add_column :users, :blacklisted, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161027190856) do
+ActiveRecord::Schema.define(version: 20190418132233) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,27 +49,14 @@ ActiveRecord::Schema.define(version: 20161027190856) do
 
   create_table "users", id: :serial, force: :cascade do |t|
     t.string "email"
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.boolean "allow_password_change", default: false
-    t.datetime "remember_created_at"
-    t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
-    t.inet "current_sign_in_ip"
-    t.inet "last_sign_in_ip"
     t.string "first_name", default: ""
     t.string "last_name", default: ""
-    t.string "username", default: ""
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "provider", default: "email", null: false
-    t.string "uid", default: "", null: false
-    t.json "tokens"
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
+    t.string "github_name"
+    t.string "slack_name"
+    t.boolean "blacklisted", default: false
+    t.index ["github_name"], name: "index_users_on_github_name"
   end
 
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :user do
     email    { Faker::Internet.unique.email }
-    username { Faker::Internet.unique.user_name }
+    github_name { Faker::Internet.unique.user_name }
+    blacklisted { false }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,32 +2,19 @@
 #
 # Table name: users
 #
-#  id                     :integer          not null, primary key
-#  email                  :string
-#  encrypted_password     :string           default(""), not null
-#  reset_password_token   :string
-#  reset_password_sent_at :datetime
-#  allow_password_change  :boolean          default(FALSE)
-#  remember_created_at    :datetime
-#  sign_in_count          :integer          default(0), not null
-#  current_sign_in_at     :datetime
-#  last_sign_in_at        :datetime
-#  current_sign_in_ip     :inet
-#  last_sign_in_ip        :inet
-#  first_name             :string           default("")
-#  last_name              :string           default("")
-#  username               :string           default("")
-#  created_at             :datetime         not null
-#  updated_at             :datetime         not null
-#  provider               :string           default("email"), not null
-#  uid                    :string           default(""), not null
-#  tokens                 :json
+#  id          :integer          not null, primary key
+#  email       :string
+#  first_name  :string           default("")
+#  last_name   :string           default("")
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  github_name :string
+#  slack_name  :string
+#  blacklisted :boolean          default(FALSE)
 #
 # Indexes
 #
-#  index_users_on_email                 (email) UNIQUE
-#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
-#  index_users_on_uid_and_provider      (uid,provider) UNIQUE
+#  index_users_on_github_name  (github_name)
 #
 
 require 'rails_helper'
@@ -38,7 +25,7 @@ describe User do
     let(:full_name) { user.full_name }
 
     it 'returns the correct name' do
-      expect(full_name).to eq(user.username)
+      expect(full_name).to eq(user.github_name)
     end
   end
 end


### PR DESCRIPTION
The idea is to not send notifications from some people. So as we are not using the user table to log in users I will repurpose (create migration to delete unused fields and add new ones)  to blacklist users (not send notifications from this users PRs). 

We have the active admin running so we can access and create an user with github_name and blacklisted = true.

Also I refactored the specs